### PR TITLE
Fixed the issue of override objetcs(run button and chat button)

### DIFF
--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -91,7 +91,7 @@ const ChatBox = ({ socketRef, roomId, username }) => {
         )}
       </div> */}
       <Popover offset={10}>
-        <PopoverTrigger className="absolute bottom-5 right-5">
+        <PopoverTrigger className="absolute bottom-24 right-5">
           <Button
             color="secondary"
             variant="flat"


### PR DESCRIPTION
Fix: #6 

This change will move the chat button higher up on the screen, preventing it from covering the "Run Code" button, regardless of the output pane's size.